### PR TITLE
Path name problem

### DIFF
--- a/sample-env
+++ b/sample-env
@@ -6,7 +6,7 @@ gobusterthreads=100             #threads to be used in gobuster
 sublist3rthreads=50             #threads to be used in sublist3r
 altdnsthreads=100               #threads to be used in altdns
 
-wordlists=wordlists=fierce_hostlist.txt,namelist.txt   #specify which wordlists you want to use from the wordlists folder. Also, you can add more wordlists to that folder and specify the name here
+wordlists=wordlists/fierce_hostlist.txt,namelist.txt   #specify which wordlists you want to use from the wordlists folder. Also, you can add more wordlists to that folder and specify the name here
 
 temp1=/data/output/temp1.txt    #temp1 file
 temp2=/data/output/temp2.txt	#temp2 file					


### PR DESCRIPTION
I think that should be / instead of = 
I am getting wordlists=fierce_hostlist.txt not found

```
gobuster     | sort: cannot read: '/opt/subscan/wordlists/wordlists=fierce_hostlist.txt': No such file or directory
```